### PR TITLE
Portal factions, portal linking, and navigation

### DIFF
--- a/Main/Dutt/Assets/PortalManager/portal_000.tscn
+++ b/Main/Dutt/Assets/PortalManager/portal_000.tscn
@@ -28,6 +28,8 @@ unique_name_in_owner = true
 shape = SubResource("CapsuleShape2D_3eg45")
 
 [node name="NavigationLink2D" type="NavigationLink2D" parent="."]
+unique_name_in_owner = true
+navigation_layers = 0
 
 [connection signal="body_entered" from="PortalArea" to="." method="_on_portal_area_body_entered"]
 [connection signal="body_exited" from="PortalArea" to="." method="_on_portal_area_body_exited"]

--- a/Main/Dutt/Assets/PortalManager/portal_manager_Script.gd
+++ b/Main/Dutt/Assets/PortalManager/portal_manager_Script.gd
@@ -9,16 +9,21 @@ func _ready():
 		portal_array.append(p)
 
 
-func teleport(body: Node2D, portal: Portal):
-	# Don't do anything if the body isn't teleportable
-	if !body.is_in_group("Teleportable"):
-		return
+func teleport(body: Node2D, from_portal: Portal, to_portal: Portal):
 
-	# This will first filter out the current portal and then pick a random portal
-	var random_portal = portal_array.filter(func(p): return p != portal).pick_random()
+	var receiving_portal : Portal
 
-	# This adds the body to the random portal to prevent teleportation loops
-	random_portal.receive_teleport_body(body)
+	# If we've provided a target portal, use that
+	if to_portal:
+		receiving_portal = to_portal
+
+	# Otherwise, pick a random portal
+	else: 
+		# This will first filter out the current portal and then pick a random neutral portal
+		receiving_portal = portal_array.filter(func(p): return p != from_portal and p.faction == "neutral").pick_random()
+	
+	# This adds the body to the receiving portal to prevent teleportation loops
+	receiving_portal.receive_teleport_body(body)
 
 	# Teleport the body
-	body.transform.origin = random_portal.transform.origin
+	body.transform.origin = receiving_portal.transform.origin

--- a/Main/Dutt/Assets/PortalManager/portal_script.gd
+++ b/Main/Dutt/Assets/PortalManager/portal_script.gd
@@ -1,17 +1,44 @@
 class_name Portal
 extends Node2D
 
+## Set the portal this portal will teleport to.
+@export var linked_portal : Portal
 
-signal teleport_requested(body: Node2D, portal: Portal)
+## Setting the portal as bidirectional will allow for navAgents to know how to use portals in both directions.
+@export var is_bidirectional := false
+
+## If the portal is neutral, it can be used by any unit in the "Teleportable" group, otherwise the unit must be in the "Teleportable" group AND the "friendly" or "hostile" group.
+@export_enum("friendly","hostile","neutral") var faction = "neutral"
+
+signal teleport_requested(body: Node2D, from_portal: Portal, to_portal: Portal)
 
 
 @onready var portal_area : Area2D = %PortalArea
-	
+@onready var nav_link : NavigationLink2D = %NavigationLink2D
+
 
 var bodies_in_area : Array[Node2D] = []
 
 
-func receive_teleport_body(body: Node2D) -> void:
+func _ready():
+	nav_link.bidirectional = is_bidirectional
+
+	nav_link.set_global_start_position(transform.origin)
+
+	if linked_portal:
+		nav_link.set_global_end_position(linked_portal.transform.origin)
+
+	match faction:
+		"friendly":
+			nav_link.set_navigation_layer_value(1, true)
+		"hostile":
+			nav_link.set_navigation_layer_value(2, true)
+		"neutral":
+			nav_link.set_navigation_layer_value(1, true)
+			nav_link.set_navigation_layer_value(2, true)
+
+
+func receive_teleport_body(body: Node2D):
 	# Prevent teleporting multiple times - called from manager
 	if bodies_in_area.has(body):
 		return
@@ -19,15 +46,16 @@ func receive_teleport_body(body: Node2D) -> void:
 	bodies_in_area.append(body)
 
 
-func _on_portal_area_body_entered(body:Node2D) -> void:
+func _on_portal_area_body_entered(body:Node2D):
 	# Prevent teleporting multiple times
-	if bodies_in_area.has(body):
+	if bodies_in_area.has(body) or !body.is_in_group("Teleportable"):
 		return
 
-	bodies_in_area.append(body)
-	teleport_requested.emit(body, self)
+	if faction == "neutral" or body.is_in_group(faction):
+		bodies_in_area.append(body)
+		teleport_requested.emit(body, self, linked_portal)
 
 
-func _on_portal_area_body_exited(body:Node2D) -> void:
+func _on_portal_area_body_exited(body:Node2D):
 	if bodies_in_area.has(body):
 		bodies_in_area.erase(body)


### PR DESCRIPTION
Navigation agents will now be able to take portals into account for pathing purposes. Portals can now be faction-specific, or neutral.
Portals now have documentation.
Portals now have linking, giving the ability to override the random portal teleportation.